### PR TITLE
docs: add catalog-info file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @loadsmart/data-engineering

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: datahub
+  description: The Metadata Platform for the Modern Data Stack
+  annotations:
+    github.com/project-slug: loadsmart/blocks
+  tags:
+    - java
+    - python
+    - javascript
+spec:
+  type: service
+  lifecycle: experimental
+  owner: data-engineering


### PR DESCRIPTION
This PR adds catalog-info and CODEOWNERS files to the repository for backstage cataloging