### PR TITLE
docs: [ROCK-3382] Update PR template to follow Loadsmart Change Management Policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,42 @@
-# ROCK-<num>: <issue title>
+## Motivation and context for the change
 
-## Description
+> Describe the motivation against creating this change and, if applicable, describe the current behavior and any relevant screenshots or diagrams (if applicable).
 
-_please describe your changes here to help reviewer_
+## A clear description of the change
 
-## Checklist
-
-This PR complies to:
-
-- [ ] Documented (API SPECs, software architecture changes, and code comments where necessary)
-- [ ] Smallest size possible
-- [ ] Synced branch with master
-- [ ] Tested locally
-- [ ] Tested on QA
-- [ ] Clog entry (if needed)
-- [ ] Production-ready
-
-## Requirements
-
-_please list any other PRs that should be merged before this_
-
-* _link 1_
-* _link 2_
-
-## How to test
-
-_please provide instructions for manual testing this PR_
+> Describe the change, including new behavior, possible impacts, and any relevant screenshots or diagrams (if applicable).
 
 ## Showroom
 
-_please include a video or screenshot_
+> Please include a video or screenshot.
 
-## Metrics
+## Testing
 
-_please provide a list of metric or analytics implemented in this PR - if applicable_
+> Inform whether or not the change is covered with automated tests.
+
+- [ ] The change is covered with automated tests
+
+#### Testing instructions
+
+> If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.
+
+## Rollback
+
+- [ ] The change can be automatically rolled back
+
+#### Rollback instructions
+
+> If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.
+
+## Jira Ticket
+
+> Please include Jira Ticket.
+
+## Change Management Labels
+
+> Based on the Loadsmart Change Management Policy, every change should be documented. The documentation must include the type of the change. Check that this PR is labeled with at least one of the following labels:
+
+- `change-type: infrastructure`
+- `change-type: source code`
+- `change-type: database`
+- `change-type: documentation`


### PR DESCRIPTION
## Motivation and context for the change

> Describe the motivation against creating this change and, if applicable, describe the current behavior and any relevant screenshots or diagrams (if applicable).

Loadsmart Change Management Policy requires some fields to be added to the PR template, and labels to be used on the PR. More info on [this thread](https://loadsmart.slack.com/archives/C0L9SFSL8/p1683660779046079).

## A clear description of the change

> Describe the change, including new behavior, possible impacts, and any relevant screenshots or diagrams (if applicable).

This PR updates the `pull_request_template.md` file to follow the new policy.

## Showroom

> Please include a video or screenshot.

This PR description is written using the new template.

## Testing

> Inform whether or not the change is covered with automated tests.

- [ ] The change is covered with automated tests

#### Testing instructions

> If the change isn't covered with automated tests, provide a detailed list of steps for the reviewer to test it. You may remove this section in case of automated tests.

Read the new template and check if it follows the guidelines [listed here](https://loadsmart.slack.com/archives/C0L9SFSL8/p1683660779046079).

## Rollback

- [ ] The change can be automatically rolled back

#### Rollback instructions

> If the rollback cannot be performed automatically, provide a detailed list of the steps needed to complete a rollback. Add any relevant link to the documentation if applicable. You may remove this section in case of support for automated rollback.

This is just a documentation change, no rollback necessary.

## Jira Ticket

> Please include Jira Ticket.

ROCK-3382

## Change Management Labels

> Based on the Loadsmart Change Management Policy, every change should be documented. The documentation must include the type of the change. Check that this PR is labeled with at least one of the following labels:

- `change-type: infrastructure`
- `change-type: source code`
- `change-type: database`
- `change-type: documentation`
